### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,6 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD }}
           source: "dist/*"
-          strip-components: 1
+          strip_components: 1
           target: ${{ secrets.SSH_PATH }}
           rm: true


### PR DESCRIPTION
Follows up on changes made in #3 that didn't work.

## Fixed
- Deploy workflow copying `dist` directory itself instead of just contents (still)