### PR TITLE
Fix ESLint no-shadow error on Typescript enums

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,9 +57,12 @@ export default [
 			},
 		},
 		rules: {
+			// Recommended
 			...typescriptPlugin.configs['strict-type-checked'].rules,
 			...typescriptPlugin.configs['stylistic-type-checked'].rules,
 
+			// Overrides
+			'no-shadow': 0, // handled by TypeScript
 			'no-undef': 0, // handled by TypeScript
 		},
 	},


### PR DESCRIPTION
### Fixed
- ESLint [no-shadow](https://eslint.org/docs/latest/rules/no-shadow) rule throwing false positive errors on TypeScript enums (see https://github.com/typescript-eslint/typescript-eslint/issues/2483)