### PR TITLE
Resolve warnings from Nu HTML checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ This is my personal website. It uses [Bootstrap](https://getbootstrap.com/), [Re
 
 ## Licensing
 
-Without a specific license, this code is the direct intellectual property of the original developer. It may not be used, modified, or shared without explicit permission.
-Please see [GitHub's guide on licensing](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository).
+Without a specific license, this code is the direct intellectual property of the original developer. It may not be used, copied, modified, or shared without explicit permission.
+Please see [GitHub's guide on licensing](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) and [choosealicense.com](https://choosealicense.com/no-permission/).
+
+For legal reasons, if you choose to contribute to this project, you agree to give up your copyright and hand over full rights to your contribution. However, you will still be attributed for your work on GitHub. Thank you!
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="UTF-8" />
-		<link rel="icon" type="image/svg+xml" href="https://static.revolt.chat/emoji/mutant/26a1.svg" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta charset="UTF-8">
+		<link rel="icon" type="image/svg+xml" href="https://static.revolt.chat/emoji/mutant/26a1.svg">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Justin McBride</title>
 		<meta name="description" content="Personal website">
 		<!-- https://web.dev/articles/defer-non-critical-css -->
-		<link rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
+		<link rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
 	</head>
 	<body>
 		<div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
 			},
 			"devDependencies": {
 				"@jstnmcbrd/eslint-config": "^1.0.0",
-				"@types/react": "^18.3.2",
+				"@types/react": "^18.3.3",
 				"@types/react-dom": "^18.3.0",
-				"@vitejs/plugin-react-swc": "^3.6.0",
+				"@vitejs/plugin-react-swc": "^3.7.0",
 				"eslint": "^8.57.0",
 				"typescript": "^5.4.5",
 				"vite": "^5.2.11"
@@ -944,14 +944,15 @@
 			}
 		},
 		"node_modules/@swc/core": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.12.tgz",
-			"integrity": "sha512-QljRxTaUajSLB9ui93cZ38/lmThwIw/BPxjn+TphrYN6LPU3vu9/ykjgHtlpmaXDDcngL4K5i396E7iwwEUxYg==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.7.tgz",
+			"integrity": "sha512-U4qJRBefIJNJDRCCiVtkfa/hpiZ7w0R6kASea+/KLp+vkus3zcLSB8Ub8SvKgTIxjWpwsKcZlPf5nrv4ls46SQ==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.2",
-				"@swc/types": "^0.1.5"
+				"@swc/types": "0.1.7"
 			},
 			"engines": {
 				"node": ">=10"
@@ -961,16 +962,16 @@
 				"url": "https://opencollective.com/swc"
 			},
 			"optionalDependencies": {
-				"@swc/core-darwin-arm64": "1.4.12",
-				"@swc/core-darwin-x64": "1.4.12",
-				"@swc/core-linux-arm-gnueabihf": "1.4.12",
-				"@swc/core-linux-arm64-gnu": "1.4.12",
-				"@swc/core-linux-arm64-musl": "1.4.12",
-				"@swc/core-linux-x64-gnu": "1.4.12",
-				"@swc/core-linux-x64-musl": "1.4.12",
-				"@swc/core-win32-arm64-msvc": "1.4.12",
-				"@swc/core-win32-ia32-msvc": "1.4.12",
-				"@swc/core-win32-x64-msvc": "1.4.12"
+				"@swc/core-darwin-arm64": "1.5.7",
+				"@swc/core-darwin-x64": "1.5.7",
+				"@swc/core-linux-arm-gnueabihf": "1.5.7",
+				"@swc/core-linux-arm64-gnu": "1.5.7",
+				"@swc/core-linux-arm64-musl": "1.5.7",
+				"@swc/core-linux-x64-gnu": "1.5.7",
+				"@swc/core-linux-x64-musl": "1.5.7",
+				"@swc/core-win32-arm64-msvc": "1.5.7",
+				"@swc/core-win32-ia32-msvc": "1.5.7",
+				"@swc/core-win32-x64-msvc": "1.5.7"
 			},
 			"peerDependencies": {
 				"@swc/helpers": "^0.5.0"
@@ -982,13 +983,14 @@
 			}
 		},
 		"node_modules/@swc/core-darwin-arm64": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.12.tgz",
-			"integrity": "sha512-BZUUq91LGJsLI2BQrhYL3yARkcdN4TS3YGNS6aRYUtyeWrGCTKHL90erF2BMU2rEwZLLkOC/U899R4o4oiSHfA==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.7.tgz",
+			"integrity": "sha512-bZLVHPTpH3h6yhwVl395k0Mtx8v6CGhq5r4KQdAoPbADU974Mauz1b6ViHAJ74O0IVE5vyy7tD3OpkQxL/vMDQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -998,13 +1000,14 @@
 			}
 		},
 		"node_modules/@swc/core-darwin-x64": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.12.tgz",
-			"integrity": "sha512-Wkk8rq1RwCOgg5ybTlfVtOYXLZATZ+QjgiBNM7pIn03A5/zZicokNTYd8L26/mifly2e74Dz34tlIZBT4aTGDA==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.7.tgz",
+			"integrity": "sha512-RpUyu2GsviwTc2qVajPL0l8nf2vKj5wzO3WkLSHAHEJbiUZk83NJrZd1RVbEknIMO7+Uyjh54hEh8R26jSByaw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1014,13 +1017,14 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm-gnueabihf": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.12.tgz",
-			"integrity": "sha512-8jb/SN67oTQ5KSThWlKLchhU6xnlAlnmnLCCOKK1xGtFS6vD+By9uL+qeEY2krV98UCRTf68WSmC0SLZhVoz5A==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.7.tgz",
+			"integrity": "sha512-cTZWTnCXLABOuvWiv6nQQM0hP6ZWEkzdgDvztgHI/+u/MvtzJBN5lBQ2lue/9sSFYLMqzqff5EHKlFtrJCA9dQ==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1030,13 +1034,14 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm64-gnu": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.12.tgz",
-			"integrity": "sha512-DhW47DQEZKCdSq92v5F03rqdpjRXdDMqxfu4uAlZ9Uo1wJEGvY23e1SNmhji2sVHsZbBjSvoXoBLk0v00nSG8w==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.7.tgz",
+			"integrity": "sha512-hoeTJFBiE/IJP30Be7djWF8Q5KVgkbDtjySmvYLg9P94bHg9TJPSQoC72tXx/oXOgXvElDe/GMybru0UxhKx4g==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1046,13 +1051,14 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm64-musl": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.12.tgz",
-			"integrity": "sha512-PR57pT3TssnCRvdsaKNsxZy9N8rFg9AKA1U7W+LxbZ/7Z7PHc5PjxF0GgZpE/aLmU6xOn5VyQTlzjoamVkt05g==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.7.tgz",
+			"integrity": "sha512-+NDhK+IFTiVK1/o7EXdCeF2hEzCiaRSrb9zD7X2Z7inwWlxAntcSuzZW7Y6BRqGQH89KA91qYgwbnjgTQ22PiQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1062,13 +1068,14 @@
 			}
 		},
 		"node_modules/@swc/core-linux-x64-gnu": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.12.tgz",
-			"integrity": "sha512-HLZIWNHWuFIlH+LEmXr1lBiwGQeCshKOGcqbJyz7xpqTh7m2IPAxPWEhr/qmMTMsjluGxeIsLrcsgreTyXtgNA==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.7.tgz",
+			"integrity": "sha512-25GXpJmeFxKB+7pbY7YQLhWWjkYlR+kHz5I3j9WRl3Lp4v4UD67OGXwPe+DIcHqcouA1fhLhsgHJWtsaNOMBNg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1078,13 +1085,14 @@
 			}
 		},
 		"node_modules/@swc/core-linux-x64-musl": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.12.tgz",
-			"integrity": "sha512-M5fBAtoOcpz2YQAFtNemrPod5BqmzAJc8pYtT3dVTn1MJllhmLHlphU8BQytvoGr1PHgJL8ZJBlBGdt70LQ7Mw==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.7.tgz",
+			"integrity": "sha512-0VN9Y5EAPBESmSPPsCJzplZHV26akC0sIgd3Hc/7S/1GkSMoeuVL+V9vt+F/cCuzr4VidzSkqftdP3qEIsXSpg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -1094,13 +1102,14 @@
 			}
 		},
 		"node_modules/@swc/core-win32-arm64-msvc": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.12.tgz",
-			"integrity": "sha512-K8LjjgZ7VQFtM+eXqjfAJ0z+TKVDng3r59QYn7CL6cyxZI2brLU3lNknZcUFSouZD+gsghZI/Zb8tQjVk7aKDQ==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.7.tgz",
+			"integrity": "sha512-RtoNnstBwy5VloNCvmvYNApkTmuCe4sNcoYWpmY7C1+bPR+6SOo8im1G6/FpNem8AR5fcZCmXHWQ+EUmRWJyuA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1110,13 +1119,14 @@
 			}
 		},
 		"node_modules/@swc/core-win32-ia32-msvc": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.12.tgz",
-			"integrity": "sha512-hflO5LCxozngoOmiQbDPyvt6ODc5Cu9AwTJP9uH/BSMPdEQ6PCnefuUOJLAKew2q9o+NmDORuJk+vgqQz9Uzpg==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.7.tgz",
+			"integrity": "sha512-Xm0TfvcmmspvQg1s4+USL3x8D+YPAfX2JHygvxAnCJ0EHun8cm2zvfNBcsTlnwYb0ybFWXXY129aq1wgFC9TpQ==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1126,13 +1136,14 @@
 			}
 		},
 		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.4.12",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.12.tgz",
-			"integrity": "sha512-3A4qMtddBDbtprV5edTB/SgJn9L+X5TL7RGgS3eWtEgn/NG8gA80X/scjf1v2MMeOsrcxiYhnemI2gXCKuQN2g==",
+			"version": "1.5.7",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.7.tgz",
+			"integrity": "sha512-tp43WfJLCsKLQKBmjmY/0vv1slVywR5Q4qKjF5OIY8QijaEW7/8VwPyUyVoJZEnDgv9jKtUTG5PzqtIYPZGnyg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -1145,7 +1156,8 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
 			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-			"dev": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/@swc/helpers": {
 			"version": "0.5.8",
@@ -1156,10 +1168,11 @@
 			}
 		},
 		"node_modules/@swc/types": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.6.tgz",
-			"integrity": "sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz",
+			"integrity": "sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3"
 			}
@@ -1192,9 +1205,10 @@
 			"integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.2",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.2.tgz",
-			"integrity": "sha512-Btgg89dAnqD4vV7R3hlwOxgqobUQKgx3MmrQRi0yYbs/P0ym8XozIAlkqVilPqHQwXs4e9Tf63rrCgl58BcO4w==",
+			"version": "18.3.3",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -1425,12 +1439,13 @@
 			"dev": true
 		},
 		"node_modules/@vitejs/plugin-react-swc": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.6.0.tgz",
-			"integrity": "sha512-XFRbsGgpGxGzEV5i5+vRiro1bwcIaZDIdBRP16qwm+jP68ue/S8FJTBEgOeojtVDYrbSua3XFp71kC8VJE6v+g==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.0.tgz",
+			"integrity": "sha512-yrknSb3Dci6svCd/qhHqhFPDSw0QtjumcqdKMoNNzmOl5lMXTTiqzjWtG4Qask2HdvvzaNgSunbQGet8/GrKdA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@swc/core": "^1.3.107"
+				"@swc/core": "^1.5.7"
 			},
 			"peerDependencies": {
 				"vite": "^4 || ^5"

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
 	},
 	"devDependencies": {
 		"@jstnmcbrd/eslint-config": "^1.0.0",
-		"@types/react": "^18.3.2",
+		"@types/react": "^18.3.3",
 		"@types/react-dom": "^18.3.0",
-		"@vitejs/plugin-react-swc": "^3.6.0",
+		"@vitejs/plugin-react-swc": "^3.7.0",
 		"eslint": "^8.57.0",
 		"typescript": "^5.4.5",
 		"vite": "^5.2.11"


### PR DESCRIPTION
Ran the [Nu HTML checker](https://validator.w3.org/nu/) from W3 and decided to fix the warnings.

-----

### Changed

- Dependencies to be up-to-date
- License statement in README to be standardized with other projects

### Removed

- Unnecessary trailing slashes from HTML elements
  ![image](https://github.com/JstnMcBrd/jstnmcbrd.com/assets/28303477/5c5550f7-b8c0-4fa3-b340-513eb749f19b)
