### PR TITLE
Alternative validation guarantee for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,20 +1,33 @@
 name: Deploy
-# Deploys the website when new changes pass validation on main
+# Deploys the website whenever changes are merged to main
 
 on:
-  workflow_run:
-    workflows: ["Validate"]
-    types: [completed]
-    branches:
-      - main
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions: {}
 
 jobs:
+  checks:
+    if: ${{ github.event_name == 'push' }}
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      checks: read # Required for lewagon/wait-on-check-action
+
+    steps:
+      - name: Wait for checks to pass
+        uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc # v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          running-workflow-name: checks
+          allowed-conclusions: success
+
   deploy:
-    # Only deploy if validation succeeds (or manually triggered)
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    needs: checks
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Currently, the deploy workflow is triggered when validation succeeds on `main`. But the deploy workflow is not associated with the same commit as the validation workflow. Instead, it uses the latest commit on `main`, which may not be the same commit if a PR is merged before validation of the previous commit succeeds.

Also, the deploy workflow does not show up in the GitHub UI in the list of checks on the commit, reducing visibility.

As an alternative, we can have the deploy workflow run on new commits on main, just like it used to - but this time, it will use a third-party action that will wait for all other checks to succeed before running.

This way deploys will always run on the same commit that passed validation, and will show up in the list of checks on the commit.

-----

### Changed

- Deploy workflow to use `lewagon/wait-on-check-action` to wait for validation to succeed instead of being triggered by validation workflow