### PR TITLE
Load `eslint.config.ts` with native Node

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,7 +1,5 @@
-/**
- * TODO Remove jiti dependency as soon as strip-types is no longer experimental in Node LTS
- * @see https://eslint.org/docs/latest/use/configure/configuration-files#native-typescript-support
- */
+// FIXME Need the `unstable_native_nodejs_ts_config` flag to use `eslint.config.ts`
+// https://github.com/eslint/eslint/issues/19985
 
 import eslintConfig from '@jstnmcbrd/eslint-config';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
 				"@types/react-dom": "^19.2.3",
 				"@vitejs/plugin-react": "^6.0.1",
 				"eslint": "^9.39.1",
-				"jiti": "^2.6.1",
 				"typescript": "^5.9.3",
 				"vite": "^8.0.5"
 			}
@@ -2420,16 +2419,6 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/jiti": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
-			}
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,11 @@
 		"eslint": "^9.39.1",
 		"typescript": "^5.9.3",
 		"vite": "^8.0.5"
+	},
+	"devEngines": {
+		"runtime": {
+			"name": "node",
+			"version": ">=22.18.0"
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"eslint": "^9.39.1",
-		"jiti": "^2.6.1",
 		"typescript": "^5.9.3",
 		"vite": "^8.0.5"
 	}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "tsc -p tsconfig.build.json && vite build",
-		"lint": "eslint",
+		"lint": "eslint --flag unstable_native_nodejs_ts_config",
 		"preview": "vite preview",
 		"start": "vite"
 	},


### PR DESCRIPTION
Pros:
- removes a dependency

Cons:
- requires an additional flag

Currently ESLint requires an experiment flag to use native Node type-stripping to load the config file, despite Node type-stripping not being experimental anymore. Hopefully this is resolved soon. 
- https://github.com/eslint/eslint/issues/19985


Also added a `devEngines` requirement because type-stripping is only stable in Node `>=22.18.0`.