### PR TITLE
Remove CI badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # jstnmcbrd.com
 
 [![Status](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/jstnmcbrd.com/status.yml?logo=github&label=Status)](https://github.com/JstnMcBrd/jstnmcbrd.com/actions/workflows/status.yml)
-[![CI](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/jstnmcbrd.com/ci.yml?logo=github&label=CI)](https://github.com/JstnMcBrd/jstnmcbrd.com/actions/workflows/ci.yml)
 
 ## About
 


### PR DESCRIPTION
Redundant - CI status is already visible